### PR TITLE
Fixed ValueError when setting enum properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Added
 - **SmartASS** window
+### Fixed
+- ValueError when setting enum properties
+([#4](https://github.com/Genhis/KRPC.MechJeb/pull/4))
 
 ## [0.4.0] - 2019-03-31
 ### Added

--- a/SmartASS.cs
+++ b/SmartASS.cs
@@ -61,7 +61,7 @@ namespace KRPC.MechJeb {
 				if(value == SmartASSInterfaceMode.Automatic)
 					throw new MJServiceException("Cannot set SmartASSInterfaceMode to Automatic");
 
-				this.mode.SetValue(this.instance, value);
+				this.mode.SetValue(this.instance, (int)value);
 			}
 		}
 
@@ -75,7 +75,7 @@ namespace KRPC.MechJeb {
 				if(value == SmartASSAutopilotMode.Automatic)
 					throw new MJServiceException("Cannot set SmartASSAutopilotMode to Automatic");
 
-				this.target.SetValue(this.instance, value);
+				this.target.SetValue(this.instance, (int)value);
 			}
 		}
 
@@ -167,14 +167,14 @@ namespace KRPC.MechJeb {
 		[KRPCProperty]
 		public AttitudeReference AdvancedReference {
 			get => (AttitudeReference)this.advReference.GetValue(this.instance);
-			set => this.advReference.SetValue(this.instance, value);
+			set => this.advReference.SetValue(this.instance, (int)value);
 		}
 
 		/// <remarks>Works only in <see cref="SmartASSAutopilotMode.Advanced" /> mode.</remarks>
 		[KRPCProperty]
 		public Vector6.Direction AdvancedDirection {
 			get => (Vector6.Direction)this.advDirection.GetValue(this.instance);
-			set => this.advDirection.SetValue(this.instance, value);
+			set => this.advDirection.SetValue(this.instance, (int)value);
 		}
 
 		/// <summary>

--- a/SmartRCS.cs
+++ b/SmartRCS.cs
@@ -27,7 +27,7 @@ namespace KRPC.MechJeb {
 		public SmartRCSMode Mode {
 			get => (SmartRCSMode)this.target.GetValue(this.instance);
 			set {
-				this.target.SetValue(this.instance, value);
+				this.target.SetValue(this.instance, (int)value);
 				this.engage.Invoke(this.instance, null);
 			}
 		}


### PR DESCRIPTION
In setter of an enum property there must be a cast of value to int.

Code:
`conn = krpc.connect()`
`mj = conn.mech_jeb`
`smart_ass = mj.smart_ass`
`smart_ass.autopilot_mode = mj.SmartASSAutopilotMode.surface`

Assigning to the autopilot_mode property was causing ValueError.
The same thing happens with other enum properties.