### PR TITLE
Update some modules for Mechjeb 2.14.3.0

### DIFF
--- a/AirplaneAutopilot.cs
+++ b/AirplaneAutopilot.cs
@@ -12,7 +12,6 @@ namespace KRPC.MechJeb {
 
 		// Fields and methods
 		private static FieldInfo headingHoldEnabled;
-
 		private static FieldInfo altitudeHoldEnabled;
 		private static FieldInfo vertSpeedHoldEnabled;
 		private static FieldInfo rollHoldEnabled;
@@ -23,16 +22,15 @@ namespace KRPC.MechJeb {
 		private static FieldInfo rollTarget;
 		private static FieldInfo speedTarget;
 		private static FieldInfo vertSpeedTarget;
-		private static FieldInfo vertSpeedMax;
-		private static FieldInfo rollMax;
+		private static FieldInfo bankAngle;
 
 		private static FieldInfo accKpField;
 		private static FieldInfo accKiField;
 		private static FieldInfo accKdField;
 
-		private static FieldInfo verKpField;
-		private static FieldInfo verKiField;
-		private static FieldInfo verKdField;
+		private static FieldInfo pitKpField;
+		private static FieldInfo pitKiField;
+		private static FieldInfo pitKdField;
 
 		private static FieldInfo rolKpField;
 		private static FieldInfo rolKiField;
@@ -43,16 +41,18 @@ namespace KRPC.MechJeb {
 		private static FieldInfo yawKdField;
 
 		private static FieldInfo yawLimitField;
+		private static FieldInfo rollLimitField;
+		private static FieldInfo pitchUpLimitField;
+		private static FieldInfo pitchDownLimitField;
 
 		// Instance objects
 		private object accKp;
-
 		private object accKi;
 		private object accKd;
 
-		private object verKp;
-		private object verKi;
-		private object verKd;
+		private object pitKp;
+		private object pitKi;
+		private object pitKd;
 
 		private object rolKp;
 		private object rolKi;
@@ -63,6 +63,9 @@ namespace KRPC.MechJeb {
 		private object yawKd;
 
 		private object yawLimit;
+		private object rollLimit;
+		private object pitchUpLimit;
+		private object pitchDownLimit;
 
 		internal static new void InitType(Type type) {
 			headingHoldEnabled = type.GetCheckedField("HeadingHoldEnabled");
@@ -76,16 +79,15 @@ namespace KRPC.MechJeb {
 			rollTarget = type.GetCheckedField("RollTarget");
 			speedTarget = type.GetCheckedField("SpeedTarget");
 			vertSpeedTarget = type.GetCheckedField("VertSpeedTarget");
-			vertSpeedMax = type.GetCheckedField("VertSpeedMax");
-			rollMax = type.GetCheckedField("RollMax");
+			bankAngle = type.GetCheckedField("BankAngle");
 
 			accKpField = type.GetCheckedField("AccKp");
 			accKiField = type.GetCheckedField("AccKi");
 			accKdField = type.GetCheckedField("AccKd");
 
-			verKpField = type.GetCheckedField("VerKp");
-			verKiField = type.GetCheckedField("VerKi");
-			verKdField = type.GetCheckedField("VerKd");
+			pitKpField = type.GetCheckedField("PitKp");
+			pitKiField = type.GetCheckedField("PitKi");
+			pitKdField = type.GetCheckedField("PitKd");
 
 			rolKpField = type.GetCheckedField("RolKp");
 			rolKiField = type.GetCheckedField("RolKi");
@@ -96,6 +98,9 @@ namespace KRPC.MechJeb {
 			yawKdField = type.GetCheckedField("YawKd");
 
 			yawLimitField = type.GetCheckedField("YawLimit");
+			rollLimitField = type.GetCheckedField("RollLimit");
+			pitchUpLimitField = type.GetCheckedField("PitchUpLimit");
+			pitchDownLimitField = type.GetCheckedField("PitchDownLimit");
 		}
 
 		protected internal override void InitInstance(object instance) {
@@ -104,9 +109,9 @@ namespace KRPC.MechJeb {
 			this.accKi = accKiField.GetInstanceValue(instance);
 			this.accKd = accKdField.GetInstanceValue(instance);
 
-			this.verKp = verKpField.GetInstanceValue(instance);
-			this.verKi = verKiField.GetInstanceValue(instance);
-			this.verKd = verKdField.GetInstanceValue(instance);
+			this.pitKp = pitKpField.GetInstanceValue(instance);
+			this.pitKi = pitKiField.GetInstanceValue(instance);
+			this.pitKd = pitKdField.GetInstanceValue(instance);
 
 			this.rolKp = rolKpField.GetInstanceValue(instance);
 			this.rolKi = rolKiField.GetInstanceValue(instance);
@@ -117,6 +122,9 @@ namespace KRPC.MechJeb {
 			this.yawKd = yawKdField.GetInstanceValue(instance);
 
 			this.yawLimit = yawLimitField.GetInstanceValue(instance);
+			this.rollLimit = rollLimitField.GetInstanceValue(instance);
+			this.pitchUpLimit = pitchUpLimitField.GetInstanceValue(instance);
+			this.pitchDownLimit = pitchDownLimitField.GetInstanceValue(instance);
 		}
 
 		[KRPCProperty]
@@ -180,15 +188,9 @@ namespace KRPC.MechJeb {
 		}
 
 		[KRPCProperty]
-		public double VertSpeedMax {
-			get => (double)vertSpeedMax.GetValue(this.instance);
-			set => vertSpeedMax.SetValue(this.instance, value);
-		}
-
-		[KRPCProperty]
-		public double RollMax {
-			get => (double)rollMax.GetValue(this.instance);
-			set => rollMax.SetValue(this.instance, value);
+		public double BankAngle {
+			get => (double)bankAngle.GetValue(this.instance);
+			set => bankAngle.SetValue(this.instance, value);
 		}
 
 		[KRPCProperty]
@@ -210,21 +212,21 @@ namespace KRPC.MechJeb {
 		}
 
 		[KRPCProperty]
-		public double VerKp {
-			get => EditableDouble.Get(this.verKp);
-			set => EditableDouble.Set(this.verKp, value);
+		public double PitKp {
+			get => EditableDouble.Get(this.pitKp);
+			set => EditableDouble.Set(this.pitKp, value);
 		}
 
 		[KRPCProperty]
-		public double VerKi {
-			get => EditableDouble.Get(this.verKi);
-			set => EditableDouble.Set(this.verKi, value);
+		public double PitKi {
+			get => EditableDouble.Get(this.pitKi);
+			set => EditableDouble.Set(this.pitKi, value);
 		}
 
 		[KRPCProperty]
-		public double VerKd {
-			get => EditableDouble.Get(this.verKd);
-			set => EditableDouble.Set(this.verKd, value);
+		public double PitKd {
+			get => EditableDouble.Get(this.pitKd);
+			set => EditableDouble.Set(this.pitKd, value);
 		}
 
 		[KRPCProperty]
@@ -267,6 +269,24 @@ namespace KRPC.MechJeb {
 		public double YawLimit {
 			get => EditableDouble.Get(this.yawLimit);
 			set => EditableDouble.Set(this.yawLimit, value);
+		}
+
+		[KRPCProperty]
+		public double RollLimit {
+			get => EditableDouble.Get(this.rollLimit);
+			set => EditableDouble.Set(this.rollLimit, value);
+		}
+
+		[KRPCProperty]
+		public double PitchUpLimit {
+			get => EditableDouble.Get(this.pitchUpLimit);
+			set => EditableDouble.Set(this.pitchUpLimit, value);
+		}
+
+		[KRPCProperty]
+		public double PitchDownLimit {
+			get => EditableDouble.Get(this.pitchDownLimit);
+			set => EditableDouble.Set(this.pitchDownLimit, value);
 		}
 	}
 }

--- a/AscentAutopilot.cs
+++ b/AscentAutopilot.cs
@@ -405,21 +405,13 @@ namespace KRPC.MechJeb {
 
 		// Fields and methods
 		private static MethodInfo timeToPhaseAngle;
-		private static MethodInfo timeToPlane;
 
 		internal static void InitType(Type type) {
 			timeToPhaseAngle = type.GetCheckedMethod("TimeToPhaseAngle");
-			timeToPlane = type.GetCheckedMethod("TimeToPlane");
 		}
 
 		public static double TimeToPhaseAngle(double launchPhaseAngle) {
 			return (double)timeToPhaseAngle.Invoke(null, new object[] { launchPhaseAngle, FlightGlobals.ActiveVessel.mainBody, GetLongtitude(), MechJeb.TargetController.TargetOrbit.InternalOrbit });
-		}
-
-		public static double TimeToPlane(double launchLANDifference) {
-			Vessel vessel = FlightGlobals.ActiveVessel;
-			CelestialBody body = vessel.mainBody;
-			return (double)timeToPlane.Invoke(null, new object[] { launchLANDifference, body, body.GetLatitude(vessel.CoMD), GetLongtitude(), MechJeb.TargetController.TargetOrbit.InternalOrbit });
 		}
 
 		private static double GetLongtitude() {

--- a/AscentPVG.cs
+++ b/AscentPVG.cs
@@ -16,18 +16,34 @@ namespace KRPC.MechJeb {
 		private static FieldInfo pitchStartVelocityField;
 		private static FieldInfo pitchRateField;
 		private static FieldInfo desiredApoapsisField;
-		private static FieldInfo omitCoast;
+		private static FieldInfo attachAltFlag;
+		private static FieldInfo desiredAttachAltField;
+		private static FieldInfo dynamicPressureTriggerField;
+		private static FieldInfo stagingTriggerField;
+		private static FieldInfo stagingTriggerFlag;
+		private static FieldInfo fixedCoast;
+		private static FieldInfo fixedCoastLengthField;
 
 		// Instance objects
 		private object pitchStartVelocity;
 		private object pitchRate;
 		private object desiredApoapsis;
+		private object desiredAttachAlt;
+		private object dynamicPressureTrigger;
+		private object stagingTrigger;
+		private object fixedCoastLength;
 
 		internal static new void InitType(Type type) {
-			pitchStartVelocityField = type.GetCheckedField("pitchStartVelocity");
-			pitchRateField = type.GetCheckedField("pitchRate");
-			desiredApoapsisField = type.GetCheckedField("desiredApoapsis");
-			omitCoast = type.GetCheckedField("omitCoast");
+			pitchStartVelocityField = type.GetCheckedField("PitchStartVelocity");
+			pitchRateField = type.GetCheckedField("PitchRate");
+			desiredApoapsisField = type.GetCheckedField("DesiredApoapsis");
+			attachAltFlag = type.GetCheckedField("AttachAltFlag");
+			desiredAttachAltField = type.GetCheckedField("DesiredAttachAlt");
+			dynamicPressureTriggerField = type.GetCheckedField("DynamicPressureTrigger");
+			stagingTriggerField = type.GetCheckedField("StagingTrigger");
+			stagingTriggerFlag = type.GetCheckedField("StagingTriggerFlag");
+			fixedCoast = type.GetCheckedField("FixedCoast");
+			fixedCoastLengthField = type.GetCheckedField("FixedCoastLength");
 		}
 
 		protected internal override void InitInstance(object instance) {
@@ -36,6 +52,10 @@ namespace KRPC.MechJeb {
 			this.pitchStartVelocity = pitchStartVelocityField.GetInstanceValue(instance);
 			this.pitchRate = pitchRateField.GetInstanceValue(instance);
 			this.desiredApoapsis = desiredApoapsisField.GetInstanceValue(instance);
+			this.desiredAttachAlt = desiredAttachAltField.GetInstanceValue(instance);
+			this.dynamicPressureTrigger = dynamicPressureTriggerField.GetInstanceValue(instance);
+			this.stagingTrigger = stagingTriggerField.GetInstanceValue(instance);
+			this.fixedCoastLength = fixedCoastLengthField.GetInstanceValue(instance);
 		}
 
 		[KRPCProperty]
@@ -60,9 +80,45 @@ namespace KRPC.MechJeb {
 		}
 
 		[KRPCProperty]
-		public bool OmitCoast {
-			get => (bool)omitCoast.GetValue(this.instance);
-			set => omitCoast.SetValue(this.instance, value);
+		public bool AttachAltFlag {
+			get => (bool)attachAltFlag.GetValue(this.instance);
+			set => attachAltFlag.SetValue(this.instance, value);
+		}
+
+		[KRPCProperty]
+		public double DesiredAttachAlt {
+			get => EditableDouble.Get(this.desiredAttachAlt);
+			set => EditableDouble.Set(this.desiredAttachAlt, value);
+		}
+
+		[KRPCProperty]
+		public double DynamicPressureTrigger {
+			get => EditableDouble.Get(this.dynamicPressureTrigger);
+			set => EditableDouble.Set(this.dynamicPressureTrigger, value);
+		}
+
+		[KRPCProperty]
+		public int StagingTrigger {
+			get => EditableInt.Get(this.stagingTrigger);
+			set => EditableInt.Set(this.stagingTrigger, value);
+		}
+
+		[KRPCProperty]
+		public bool StagingTriggerFlag {
+			get => (bool)stagingTriggerFlag.GetValue(this.instance);
+			set => stagingTriggerFlag.SetValue(this.instance, value);
+		}
+
+		[KRPCProperty]
+		public bool FixedCoast {
+			get => (bool)fixedCoast.GetValue(this.instance);
+			set => fixedCoast.SetValue(this.instance, value);
+		}
+
+		[KRPCProperty]
+		public double FixedCoastLength {
+			get => EditableDouble.Get(this.fixedCoastLength);
+			set => EditableDouble.Set(this.fixedCoastLength, value);
 		}
 	}
 }

--- a/docs/order.txt
+++ b/docs/order.txt
@@ -20,28 +20,30 @@ MechJeb.Translatron
 MechJeb.AirplaneAutopilot.Enabled
 MechJeb.AirplaneAutopilot.AltitudeHoldEnabled
 MechJeb.AirplaneAutopilot.AltitudeTarget
+MechJeb.AirplaneAutopilot.BankAngle
 MechJeb.AirplaneAutopilot.HeadingHoldEnabled
 MechJeb.AirplaneAutopilot.HeadingTarget
 MechJeb.AirplaneAutopilot.RollHoldEnabled
-MechJeb.AirplaneAutopilot.RollMax
 MechJeb.AirplaneAutopilot.RollTarget
 MechJeb.AirplaneAutopilot.SpeedHoldEnabled
 MechJeb.AirplaneAutopilot.SpeedTarget
 MechJeb.AirplaneAutopilot.VertSpeedHoldEnabled
-MechJeb.AirplaneAutopilot.VertSpeedMax
 MechJeb.AirplaneAutopilot.VertSpeedTarget
 MechJeb.AirplaneAutopilot.AccKd
 MechJeb.AirplaneAutopilot.AccKi
 MechJeb.AirplaneAutopilot.AccKp
+MechJeb.AirplaneAutopilot.PitKd
+MechJeb.AirplaneAutopilot.PitKi
+MechJeb.AirplaneAutopilot.PitKp
 MechJeb.AirplaneAutopilot.RolKd
 MechJeb.AirplaneAutopilot.RolKi
 MechJeb.AirplaneAutopilot.RolKp
-MechJeb.AirplaneAutopilot.VerKd
-MechJeb.AirplaneAutopilot.VerKi
-MechJeb.AirplaneAutopilot.VerKp
 MechJeb.AirplaneAutopilot.YawKd
 MechJeb.AirplaneAutopilot.YawKi
 MechJeb.AirplaneAutopilot.YawKp
+MechJeb.AirplaneAutopilot.PitchDownLimit
+MechJeb.AirplaneAutopilot.PitchUpLimit
+MechJeb.AirplaneAutopilot.RollLimit
 MechJeb.AirplaneAutopilot.YawLimit
 
 MechJeb.AscentAutopilot.Enabled
@@ -97,10 +99,16 @@ MechJeb.AscentLaunchMode.Rendezvous
 MechJeb.AscentLaunchMode.TargetPlane
 MechJeb.AscentLaunchMode.Unknown
 
+MechJeb.AscentPVG.AttachAltFlag
 MechJeb.AscentPVG.DesiredApoapsis
-MechJeb.AscentPVG.PitchStartVelocity
+MechJeb.AscentPVG.DesiredAttachAlt
+MechJeb.AscentPVG.DynamicPressureTrigger
+MechJeb.AscentPVG.FixedCoast
+MechJeb.AscentPVG.FixedCoastLength
 MechJeb.AscentPVG.PitchRate
-MechJeb.AscentPVG.OmitCoast
+MechJeb.AscentPVG.PitchStartVelocity
+MechJeb.AscentPVG.StagingTrigger
+MechJeb.AscentPVG.StagingTriggerFlag
 
 MechJeb.AttitudeReference.Inertial
 MechJeb.AttitudeReference.Orbit


### PR DESCRIPTION
I've only updated the modules that are causing the "kRPC.MechJeb may not work properly" window to pop up. Did a quick test with python on linux with msbuild and everything seems to work.

`MuMech.LaunchTiming.TimeToPlane` got moved to `MuMechLib.Maths.TimeToPlane`. Not sure how you want to handle this so I've just removed it for now.